### PR TITLE
  【会員】退会確認画面の作成

### DIFF
--- a/app/controllers/customers/sessions_controller.rb
+++ b/app/controllers/customers/sessions_controller.rb
@@ -1,27 +1,4 @@
 # frozen_string_literal: true
 
 class Customers::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
 end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -22,6 +22,11 @@ class Public::CustomersController < ApplicationController
   end
 
   def quit
+    @customer = current_customer
+    @customer.is_deleted = true
+    @customer.save
+    reset_session #ログアウト
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,13 +1,21 @@
 class Public::CustomersController < ApplicationController
 
   def show
-    @customer = Customer.find(current_customer.id)
+    @customer = current_customer
   end
 
   def edit
+    @customer = current_customer
   end
 
   def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      flash[:notice]="会員情報を更新しました"
+      redirect_to customers_path
+    else
+      render "edit"
+    end
   end
 
   def quit_confirm
@@ -15,5 +23,11 @@ class Public::CustomersController < ApplicationController
 
   def quit
   end
+
+  private
+
+    def customer_params
+      params.require(:customer).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :postcode, :address, :phone_number, :is_deleted)
+    end
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -30,4 +30,9 @@ class Customer < ApplicationRecord
     self.last_name_kana + " " + self.first_name_kana
   end
 
+  #退会していたらtrueを返す
+  def active_for_authentication?
+    super && (self.is_deleted == false)
+  end
+
 end

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,0 +1,51 @@
+<div class="container">
+  <div class="row">
+    <div class="col offset-1">
+      <h4>会員情報編集</h4>
+    </div>
+  </div>
+  <%= form_with model: @customer, url: customers_path, local: true do |f| %>
+    <%= render "layouts/errors", obj: @customer %>
+    <div class="row">
+      <div class="col-2"><%= f.label "名前", class:"w-100" %></div>
+      <div class="col-1 text-right p-0">(姓)　</div>
+      <div class="col-3"><%= f.text_field :last_name, placeholder: "令和", class:"w-100" %></div>
+      <div class="col-1 text-right p-0">(名)　</div>
+      <div class="col-3"><%= f.text_field :first_name, placeholder: "道子", class:"w-100" %></div>
+    </div>
+
+    <div class="row">
+      <div class="col-2"><%= f.label "フリガナ", class:"w-100" %></div>
+      <div class="col-1 text-right p-0">(セイ)</div>
+      <div class="col-3"><%= f.text_field :last_name_kana, placeholder: "レイワ", class:"w-100" %></div>
+      <div class="col-1 text-right p-0">(メイ)</div>
+      <div class="col-3"><%= f.text_field :first_name_kana, placeholder: "ミチコ", class:"w-100" %></div>
+    </div>
+
+    <div class="row">
+      <div class="col-3"><%= f.label "郵便番号(ハイフンなし)", class:"w-100" %></div>
+      <div class="col-3"><%= f.text_field :postcode, placeholder: "0000000", class:"w-100"%></div>
+    </div>
+
+    <div class="row">
+      <div class="col-3"><%= f.label "住所", class:"w-100" %></div>
+      <div class="col-7"><%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", class:"w-100" %></div>
+    </div>
+
+    <div class="row">
+      <div class="col-3"><%= f.label "電話番号(ハイフンなし)", class:"w-100" %></div>
+      <div class="col-3"><%= f.text_field :phone_number, placeholder: "00000000000", class:"w-100" %></div>
+    </div>
+
+    <div class="row">
+      <div class="col-3"><%= f.label "メールアドレス", class:"w-100" %></div>
+      <div class="col-3"><%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "sample@example.com", class:"w-100" %></div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-3"></div>
+      <div class="col-3"><%= f.submit "編集内容を保存", class:"btn btn-success w-100" %></div>
+      <div class="col-2 offset-2"><%= link_to "退会する", quit_confirm_customers_path, class:"btn btn-danger w-100" %></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/public/customers/quit_confirm.html.erb
+++ b/app/views/public/customers/quit_confirm.html.erb
@@ -1,0 +1,18 @@
+<div class="container">
+  <div class="row mt-5">
+    <div class="col text-center font-weight-bold">本当に退会しますか？</div>
+  </div>
+
+  <div class="row mt-5">
+    <div class="col text-center">
+      退会すると、会員登録情報や</br>
+      これまでの購入履歴が閲覧できなくなります。</br>
+      退会する場合は、「退会する」をクリックしてください。
+    </div>
+  </div>
+
+  <div class="row d-flex justify-content-center mt-5">
+    <%= link_to "退会しない", customers_path, class:"col-2 btn btn-primary mr-3" %>
+    <%= link_to "退会する", quit_customers_path, method: :PATCH, class:"col-2 btn btn-danger" %>
+  </div>
+</div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-3">
-      <%= render "public/items/genre_search", genres: @genres %>
+      <%= render "public/homes/genre_search", genres: @genres %>
     </div>
 
     <div class="col-9">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,5 @@
 Rails.application.routes.draw do
-
-  devise_for :admin, controllers: {
-    sessions: 'admin/sessions',
-    passwords: 'admin/passwords',
-    registrations: 'admin/registrations'
-  }
-
-  devise_for :customers, controllers: {
-    sessions: 'customers/sessions',
-    passwords: 'customers/passwords',
-    registrations: 'customers/registrations'
-  }
-
+  
   scope module: 'public' do
 
     root 'homes#top'
@@ -45,4 +33,16 @@ Rails.application.routes.draw do
     resources  :orders,      only:[:index,:show,:update]
     resources  :order_lists, only:[:update]
   end
+
+  devise_for :admin, controllers: {
+    sessions: 'admin/sessions',
+    passwords: 'admin/passwords',
+    registrations: 'admin/registrations'
+  }
+
+  devise_for :customers, controllers: {
+    sessions: 'customers/sessions',
+    passwords: 'customers/passwords',
+    registrations: 'customers/registrations'
+  }
 end


### PR DESCRIPTION
- 退会したユーザは再度ログインできないように、customerモデルにメソッドを追加しています
- [リンク](https://qiita.com/yuto_1014/items/358d0a425193b12c969a)を参考に作成しました
- [active_for_authentication?](https://qiita.com/yuto_1014/items/358d0a425193b12c969a#userrb)を定義してありますが、これがdeviseのデフォルトのメソッドを上書きしているようで、その下のsessionコントローラへの記述は不要でした。
（メソッド名を別名にして下のような記述をしようとしたのですが、うまくいかず諦めました。deviseのデフォルト機能を頼ろうと思います。）

close #25 